### PR TITLE
Fix sourcemap composition, add `file` getter

### DIFF
--- a/src/sourcemap.ml
+++ b/src/sourcemap.ml
@@ -84,21 +84,26 @@ let find_original map generated =
 (* for each mapping in `map`, update to the `original` info corresponding to
    that loc in map2 *)
 let compose map map2 =
-  let mappings, names = List.fold_left (fun (mappings, names) mapping ->
-    let mapping, names = match mapping.original with
-    | Some { original_loc; _ } ->
-      begin match find_original map2 original_loc with
-      | Some ({ name; _ } as original) ->
-        let mapping = { mapping with original = Some original } in
-        let names = match name with Some name -> SSet.add name names | None -> names in
-        mapping, names
-      | None -> mapping, names
-      end
-    | None -> mapping, names
-    in
-    mapping::mappings, names
-  ) ([], map.names) map.mappings in
-  { map with mappings = List.rev mappings; names }
+  let mappings, names, sources_contents =
+    List.fold_left (fun (mappings, names, sources_contents) mapping ->
+      match mapping.original with
+      | Some { original_loc; _ } ->
+        begin match find_original map2 original_loc with
+        | Some ({ name; source; _ } as original) ->
+          let mapping = { mapping with original = Some original } in
+          let names = match name with Some name -> SSet.add name names | None -> names in
+          let sources_contents =
+            match SMap.find_opt source map2.sources_contents with
+            | Some content -> SMap.add source content sources_contents
+            | _ -> sources_contents
+          in
+          mapping::mappings, names, sources_contents
+        | None -> mappings, names, sources_contents
+        end
+      | None -> mappings, names, sources_contents
+  ) ([], SSet.empty, SMap.empty) map.mappings in
+  { map with mappings = List.rev mappings; names; sources_contents;
+    source_root = map2.source_root }
 
 let add_mapping ~original ~generated map =
   let names = match original.name with
@@ -291,6 +296,7 @@ let sources_contents map =
 let version _map = "3"
 let names map = SSet.elements map.names
 let source_root map = map.source_root
+let file map = map.file
 
 module type Json_writer_intf = sig
   type t

--- a/src/sourcemap.mli
+++ b/src/sourcemap.mli
@@ -27,6 +27,7 @@ val add_mapping: original:original -> generated:line_col -> t -> t
 val add_source_content: source:string -> content:string -> t -> t
 
 val version: t -> string
+val file: t -> string option
 val string_of_mappings: t -> string
 val names: t -> string list
 val source_root: t -> string option

--- a/test/compose_test.ml
+++ b/test/compose_test.ml
@@ -9,30 +9,90 @@ open OUnit2
 open Sourcemaps
 open Test_utils
 
-let bar = Sourcemap.({
-  source = "bar.js";
-  original_loc = { line = 10; col = 5 };
-  name = None;
+(**
+ * Imagine we have three versions of the same file from a transformation pipeline.
+ * /v2_files/v2.js was generated from /v1_files/v1.js and produced a map: map_1_2
+ * /v3_files/v3.js was generated from /v2_files/v2.js and produced a map: map_2_3
+ * We want to reconstruct map_1_3 by composing the two maps.
+ *)
+
+let v1_source = "a\nb"
+let v2_source = "// Preamble\nA B"
+let v3_source = "a\n\nb"
+
+let v1_a = Sourcemap.({
+  source = "v1.js";
+  original_loc = { line = 1; col = 0 };
+  name = Some "a";
 })
-let foo = Sourcemap.({
-  source = "foo.js";
-  original_loc = { line = 3; col = 1 };
-  name = None;
+
+let v1_b = Sourcemap.({
+  source = "v1.js";
+  original_loc = { line = 2; col = 0 };
+  name = Some "b";
 })
-let map =
-  Sourcemap.create ()
-  |> Sourcemap.add_mapping ~original:foo ~generated:{ Sourcemap.line = 1; col = 1 }
-let map2 =
-  Sourcemap.create ()
-  |> Sourcemap.add_mapping ~original:bar ~generated:{ Sourcemap.line = 3; col = 1 }
+
+let v2_a = Sourcemap.({
+  source = "v2.js";
+  original_loc = { line = 2; col = 0 };
+  name = Some "A";
+})
+
+let v2_b = Sourcemap.({
+  source = "v2.js";
+  original_loc = { line = 1; col = 2 };
+  name = Some "B";
+})
+
+let v3_a = Sourcemap.({
+  source = "v3.js";
+  original_loc = { line = 1; col = 0 };
+  name = Some "a";
+})
+
+let v3_b = Sourcemap.({
+  source = "v3.js";
+  original_loc = { line = 3; col = 0 };
+  name = Some "b";
+})
+
+let map_1_2 =
+  Sourcemap.create () ~file:"v2.js" ~source_root:"/v1_files/"
+  |> Sourcemap.add_mapping ~original:v1_b ~generated:v2_b.Sourcemap.original_loc
+  |> Sourcemap.add_mapping ~original:v1_a ~generated:v2_a.Sourcemap.original_loc
+  |> Sourcemap.add_source_content ~source:"v1.js" ~content:v1_source
+
+let map_2_3 =
+  Sourcemap.create () ~file:"v3.js" ~source_root:"/v2_files/"
+  |> Sourcemap.add_mapping ~original:v2_a ~generated:v3_a.Sourcemap.original_loc
+  |> Sourcemap.add_mapping ~original:v2_b ~generated:v3_b.Sourcemap.original_loc
+  |> Sourcemap.add_source_content ~source:"v2.js" ~content:v2_source
 
 let tests = "compose" >::: [
   "basic" >:: begin fun ctxt ->
     let expected =
-      Sourcemap.create ()
-      |> Sourcemap.add_mapping ~original:bar ~generated:{ Sourcemap.line = 1; col = 1 }
+      Sourcemap.create () ~file:"v3.js" ~source_root:"/v1_files/"
+      |> Sourcemap.add_mapping ~original:v1_a ~generated:v3_a.Sourcemap.original_loc
+      |> Sourcemap.add_mapping ~original:v1_b ~generated:v3_b.Sourcemap.original_loc
+      |> Sourcemap.add_source_content ~source:"v1.js" ~content:v1_source
     in
-    let map3 = Sourcemap.compose map map2 in
-    assert_equal_sourcemaps ~ctxt expected map3
+    let map_1_3 = Sourcemap.compose map_2_3 map_1_2 in
+    assert_equal_sourcemaps ~ctxt expected map_1_3
+  end;
+  "empty_map_2_3" >:: begin fun ctxt ->
+    let expected =
+      Sourcemap.create () ~file:"v3.js" ~source_root:"/v1_files/"
+    in
+    let map_2_3 = Sourcemap.create () ~file:"v3.js" ~source_root:"/v2_files/" in
+    let map_1_3 = Sourcemap.compose map_2_3 map_1_2 in
+    assert_equal_sourcemaps ~ctxt expected map_1_3
+  end;
+  "empty_map_1_2" >:: begin fun ctxt ->
+    let expected =
+      Sourcemap.create () ~file:"v3.js" ~source_root:"/v1_files/"
+    in
+    let map_1_2 = Sourcemap.create () ~file:"v2.js" ~source_root:"/v1_files/" in
+    let map_1_3 = Sourcemap.compose map_2_3 map_1_2 in
+    assert_equal_sourcemaps ~ctxt expected map_1_3
   end;
 ]

--- a/test/test_utils.ml
+++ b/test/test_utils.ml
@@ -8,6 +8,10 @@
 open OUnit2
 open Sourcemaps
 
+let opt_printer x =
+  match x with
+  | Some x -> x
+  | None -> "<None>"
 let assert_equal_sourcemaps ~ctxt expected actual =
   assert_equal ~ctxt ~msg:"Versions not equal"
     (Sourcemap.version expected) (Sourcemap.version actual);
@@ -16,9 +20,12 @@ let assert_equal_sourcemaps ~ctxt expected actual =
   assert_equal ~ctxt ~msg:"Source root not equal"
     (Sourcemap.source_root expected) (Sourcemap.source_root actual);
   assert_equal ~ctxt ~msg:"Names not equal"
-    (Sourcemap.names expected) (Sourcemap.names actual);
+    (Sourcemap.names expected) (Sourcemap.names actual) ~printer:(String.concat "; ");
   assert_equal ~ctxt ~msg:"Mappings not equal" ~printer:(fun x -> x)
     (Sourcemap.string_of_mappings expected) (Sourcemap.string_of_mappings actual);
   assert_equal ~ctxt ~msg:"Source content not equal"
     (Sourcemap.sources_contents expected) (Sourcemap.sources_contents actual);
-  assert_equal ~ctxt expected actual
+  assert_equal ~ctxt ~msg:"File not equal"
+    (Sourcemap.file expected) (Sourcemap.file actual) ~printer:opt_printer;
+  assert_equal ~ctxt ~msg:"Source root not equal"
+    (Sourcemap.source_root expected) (Sourcemap.source_root actual) ~printer:opt_printer


### PR DESCRIPTION
The output of `Sourcemap.compose` was previously inaccurate. Mappings, names, sources and contents from _both_ maps would be combined incorrectly and cause issues for consuming tools downstream. This fixes the various issues and strengthens the tests.

These changes were first made in the `flow` repo: https://github.com/facebook/flow/commit/7bea51587efb384e89c4a6257600beed7c7df80f

Tests pass (`dune runtest`).